### PR TITLE
fixing content not load

### DIFF
--- a/packages/mars-theme/src/components/post.js
+++ b/packages/mars-theme/src/components/post.js
@@ -48,7 +48,7 @@ const Html2React = libraries.html2react.Component;
   }, [actions.source]);
 
   // Load the post, but only if the data is ready.
-  return data.isReady ? (
+  return data.isReady && (
     <Container>
       <div>
         <Title dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
@@ -81,16 +81,14 @@ const Html2React = libraries.html2react.Component;
         // which already contains the thumbnail.
         <div dangerouslySetInnerHTML={{ __html: post.description.rendered }} />
       ) : (
-        // Render the content using the Html2React component so the HTML is
-        // processed by the processors we included in the
-        // libraries.html2react.processors array.
         <Content>
-          <Html2React html={post.content.rendered} />
+          <div dangerouslySetInnerHTML={{ __html: post.content.rendered }} />
         </Content>
+       
         )}
         <Comments postId={post.id} />
     </Container>
-  ) : null;
+  );
 };
 
 export default connect(Post);


### PR DESCRIPTION
hello, according to this issue https://github.com/triabagus/frontity-storylabs/issues/2, i have been fixing content not load. why the content not load? because in html2react for default not handle tag style. but, let me know if there is a better code. if you want to merge this pull request, please don't forget to add label **hacktoberfest-accepted**.
thank you.